### PR TITLE
Add valgrind to CI

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -53,4 +53,10 @@ jobs:
 
       - name: Run clang-tidy (Python)
         working-directory: python
-        run: pip install . --no-build-isolation --verbose --config-settings=cmake.define.ENABLE_CLANG_TIDY=ON
+        run: >
+          pip install . 
+          --no-build-isolation
+          --verbose
+          --config-settings=cmake.build-type="${BUILD_TYPE}"
+          --config-settings=cmake.define.CXX_FLAGS="${CXX_FLAGS}"
+          --config-settings=cmake.define.ENABLE_CLANG_TIDY=ON

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -53,7 +53,12 @@ jobs:
 
       - name: Install (Python)
         working-directory: python
-        run: pip install .[typing] --no-build-isolation --verbose --config-settings=cmake.build-type="${BUILD_TYPE}"
+        run: >
+          pip install .[typing]
+          --no-build-isolation
+          --verbose
+          --config-settings=cmake.build-type="${BUILD_TYPE}"
+          --config-settings=cmake.define.CXX_FLAGS="${CXX_FLAGS}"
 
       - name: Run mypy
         run: mypy -p extension_template --config-file python/pyproject.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,12 @@ jobs:
 
       - name: Install extension_template (Python)
         working-directory: python
-        run: pip install .[test] --no-build-isolation --verbose --config-settings=cmake.build-type="${BUILD_TYPE}"
+        run: >
+          pip install .[test]
+          --no-build-isolation
+          --verbose
+          --config-settings=cmake.build-type="${BUILD_TYPE}"
+          --config-settings=cmake.define.CXX_FLAGS="${CXX_FLAGS}"
 
       - name: Run tests (Python)
         working-directory: python/test

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,78 @@
+name: valgrind
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  valgrind:
+    runs-on: ubuntu-latest
+    container: ghcr.io/fenics/dolfinx/dev-env:current-mpich
+    env:
+      CC: cc
+      CXX: c++
+      PETSC_ARCH: linux-gnu-real64-32
+      BUILD_TYPE: Debug
+      CXX_FLAGS: "-Wall -Werror -g -pedantic -Ofast -march=native"
+      PYTHONPATH: "/usr/local/dolfinx-${PETSC_TYPE}/lib/python3.12/dist-packages:/usr/local/lib"
+      LD_LIBRARY_PATH: "/usr/local/petsc/${PETSC_ARCH}/lib/:/usr/local"
+      DEB_PYTHON_INSTALL_LAYOUT: deb_system
+      VALGRIND_FLAGS: "--leak-check=full --show-leak-kinds=definite,indirect --errors-for-leak-kinds=definite,indirect --error-exitcode=1 --read-var-info=yes --track-origins=yes"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load environment variables
+        run: cat .github/workflows/.env >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y valgrind libgtest-dev
+
+      - name: Install DOLFINx
+        uses: jorgensd/actions/install-dolfinx@v0.4
+        with:
+          ufl-repository: ${{ env.REPOSITORY-UFL }}
+          ufl: ${{ env.BRANCH-UFL }}
+          basix-repository: ${{ env.REPOSITORY-BASIX }}
+          basix: ${{ env.BRANCH-BASIX }}
+          ffcx-repository: ${{ env.REPOSITORY-FFCX }}
+          ffcx: ${{ env.BRANCH-FFCX }}
+          dolfinx-repository: ${{ env.REPOSITORY-DOLFINX }}
+          dolfinx: ${{ env.BRANCH-DOLFINX }}
+          petsc_arch: ${{ env.PETSC_ARCH }}
+
+      - name: Build (C++)
+        working-directory: cpp/
+        run: |
+          cmake -G Ninja -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
+          cmake --build build
+          cmake --install build
+
+      - name: Run valgrind on tests (C++)
+        working-directory: cpp/build
+        run: valgrind ${VALGRIND_FLAGS} ctest -V
+
+      - name: Build demos (C++)
+        working-directory: cpp/demo
+        run: |
+          cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_FLAGS="${CXX_FLAGS}"
+          cmake --build build
+
+      - name: Run valgrind on demos (C++)
+        working-directory: cpp/demo/build
+        run: valgrind ${VALGRIND_FLAGS} ./simple/demo_simple
+
+      - name: Install (Python)
+        working-directory: python
+        run: >
+          pip install .[test]
+          --no-build-isolation
+          --verbose
+          --config-settings=cmake.build-type="${BUILD_TYPE}"
+          --config-settings=cmake.define.CXX_FLAGS="${CXX_FLAGS}"
+
+      - name: Run valgrind on tests (Python)
+        run: valgrind ${VALGRIND_FLAGS} pytest python/test -v

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@
 ![ruff-workflow](https://github.com/schnellerhase/dolfinx-extension-template/actions/workflows/ruff.yml/badge.svg)
 ![mypy-workflow](https://github.com/schnellerhase/dolfinx-extension-template/actions/workflows/mypy.yml/badge.svg)
 ![clang-tidy-workflow](https://github.com/schnellerhase/dolfinx-extension-template/actions/workflows/clang-tidy.yml/badge.svg)
+![valgrind-workflow](https://github.com/schnellerhase/dolfinx-extension-template/actions/workflows/valgrind.yml/badge.svg)
 
 A quick start template for the creation of extension modules on top of the [DOLFINx](https://github.com/feniCS/dolfinx) library, the problem solving environment of the [FEniCS project](https://fenicsproject.org/).


### PR DESCRIPTION
Adds a `valgrind` check to the CI.

Also, adds the `CXX_FLAGS` github argument to all Python installs in the CI.